### PR TITLE
Added Easy Spin platform but didn't compile....

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ export default [
     author_url: "mailto:blah@example.com", // Or a regular web link
     categories: ["Flanger", "Reverb"], // Required, at least 1
     download: { // Required
-      spn: { // or "spbk" or "spcd"
+      spn: { // or "spbk", "spcd", "hex", or "zip"
         // Either file or url. You don't need both.
         file: "flange_verb.spn",
       }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,7 +16,7 @@
       </div>
 
       <h2>Circuit / PCB</h2>
-      <p>Unless otherwise noted, all of these programs are assumed to work on the <a target="_blank" href="images/fv1-typical-application.png">"typical application"</a> circuit from the <a target="_blank" href="http://spinsemi.com/Products/datasheets/spn1001/FV-1.pdf">FV-1 datasheet</a>, and should also run fine on either the <strong><a target="_blank" href="https://github.com/mstratman/fv1-pedal-platform"><strong>Mimir's Well:</strong> FV-1 platform pedal</a></strong>, or the <a target="_blank" href="https://www.pedalpcb.com/product/arachnid/">Arachnid board from PedalPCB</a>.</p>
+      <p>Unless otherwise noted, all of these programs are assumed to work on the <a target="_blank" href="images/fv1-typical-application.png">"typical application"</a> circuit from the <a target="_blank" href="http://spinsemi.com/Products/datasheets/spn1001/FV-1.pdf">FV-1 datasheet</a>, and should also run fine on the <strong><a target="_blank" href="https://github.com/mstratman/fv1-pedal-platform"><strong>Mimir's Well:</strong> FV-1 platform pedal</a></strong>, <a target="_blank" href="https://audiofab.com/products/easy-spin">Easy Spin pedal</a>, or the <a target="_blank" href="https://www.pedalpcb.com/product/arachnid/">Arachnid board from PedalPCB</a>.</p>
       <p>You can also <a href="https://shop.mas-effects.com/collections/diy/products/custom-fv-1-eeprom" target="_blank">get pre-programmed EEPROMs here</a>.</p>
       <!--
       <div class="center-buttons">
@@ -168,6 +168,7 @@
             <a v-if="p.download.spbk" class="button button-primary keep-case" target="_blank" :href="p.download.spbk.url || `files/${p.download.spbk.file}`">Download SpinCAD Bank</a>
             <a v-if="p.download.spcd" class="button button-primary keep-case" target="_blank" :href="p.download.spcd.url || `files/${p.download.spcd.file}`">Download SpinCAD</a>
             <a v-if="p.download.hex" class="button button-primary keep-case" target="_blank" :href="p.download.hex.url || `files/${p.download.hex.file}`">Download Hex</a>
+            <a v-if="p.download.zip" class="button button-primary keep-case" target="_blank" :href="p.download.zip.url || `files/${p.download.zip.file}`">Download Zip</a>
           </div>
         </div>
 

--- a/programs.js
+++ b/programs.js
@@ -2219,5 +2219,13 @@ and shimmer code with some changes such as:
     },
     source_url: "http://www.spinsemi.com/forum/viewtopic.php?f=4&t=296",
   },
-
+  {
+    name: "Distortion Algorithms",
+    author: "Audiofab",
+    categories: ["Distortion"],
+    download: {
+      spn: { url: "https://audiofab.com/s/Audiofab_Distortion_Programs.zip" },
+    },
+    source_url: "https://audiofab.com/downloads",
+  }
 ]


### PR DESCRIPTION
NPM and the entire ecosystem is an unstable house of cards. Despite zero code or depency changes, somebody upstream decided to make breaking changes to one or more dependencies, or build tools.

I can no longer get this to build on Mac. I do not have time to rewrite or modify this.

TODO:
* `npm run dev`
* Verify:
  * "Easy Spin" platform is listed at the top of the index page. Link works.
  * "Distortion algorithms" appears under distortion cateogory. Download link works
* `npm run generate`
* commit new build
* Update pull request.